### PR TITLE
--no-conect option

### DIFF
--- a/pdb4amber/pdb4amber.py
+++ b/pdb4amber/pdb4amber.py
@@ -416,6 +416,7 @@ def run(arg_pdbout, arg_pdbin,
         arg_logfile='pdb4amber.log',
         arg_keep_altlocs=False,
         arg_leap_template=False,
+        arg_conect=True,
         ):
 
     # always reset handlers to avoid duplication if run method is called more
@@ -571,7 +572,7 @@ def run(arg_pdbout, arg_pdbin,
                 oatom.altloc = ''
     if arg_pdbout in ['stdout', 'stderr'] or arg_pdbout.endswith('.pdb'):
         output = pdbfixer._write_pdb_to_stringio(cys_cys_atomidx_set=cys_cys_atomidx_set,
-                disulfide_conect=True,
+                disulfide_conect=arg_conect,
                 **write_kwargs)
         output.seek(0)
         if arg_pdbout in ['stdout', 'stderr']:
@@ -643,6 +644,8 @@ def main():
                         help="version")
     parser.add_argument("--leap-template", action='store_true', dest="leap_template",
                         help="write a leap template for easy adaption\n(EXPERIMENTAL)")
+    parser.add_argument("--no-conect", action='store_true', dest="no_conect",
+                        help="Not write S-S conect record")
     opt = parser.parse_args()
 
     # pdbin : {str, file object, parmed.Structure}
@@ -681,7 +684,8 @@ def main():
         arg_keep_altlocs=opt.keep_altlocs,
         arg_add_missing_atoms=opt.add_missing_atoms,
         arg_logfile=logfile,
-        arg_leap_template=opt.leap_template)
+        arg_leap_template=opt.leap_template,
+        arg_conect=not opt.no_conect)
 
 if __name__ == '__main__':
     main()

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -83,6 +83,26 @@ def test_dry():
         water_parm = pmd.load_file('out_water.pdb')
         assert set(res.name for res in water_parm.residues) == {'HOH'}
 
+def test_not_write_sslink_conect_record():
+    pdb_out = 'out.pdb'
+    pdb_fn = get_fn('4lzt/4lzt_h.pdb')
+    sslink_name = 'out_sslink'
+
+    # has conect
+    with tempfolder():
+        command = ['pdb4amber', '-i', pdb_fn, '-o', pdb_out]
+        subprocess.check_call(command)
+        with open(pdb_out) as fh:
+            assert 'CONECT' in fh.read()
+
+    # no conect
+    with tempfolder():
+        command = ['pdb4amber', '-i', pdb_fn, '-o', pdb_out, '--no-conect']
+        subprocess.check_call(command)
+        with open(pdb_out) as fh:
+            assert 'CONECT' not in fh.read()
+
+
 def test_write_sslink():
     pdb_out = 'out.pdb'
     pdb_fn = get_fn('4lzt/4lzt_h.pdb')


### PR DESCRIPTION
when building structure for phenix, amber_adaptbx specify bond in tleap command and tleap won't be happy if both both command and conect record co-exists. 