### PR TITLE
Add simple CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(pdb4amber)
+
+install_python_library()


### PR DESCRIPTION
This will allow CMake to build pdb4amber.  This tool was added recently enough that I hadn't gotten around to making a build system for it.